### PR TITLE
collect the base fee instead of burning it

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -460,7 +460,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
 
 		// collect base fee instead of burn
-		if st.evm.Context.Coinbase.Cmp(common.Address{}) != 0 {
+		if rules.IsLondon && st.evm.Context.Coinbase.Cmp(common.Address{}) != 0 {
 			baseFee := new(big.Int).SetUint64(st.gasUsed())
 			baseFee.Mul(baseFee, st.evm.Context.BaseFee)
 			st.state.AddBalance(st.evm.Context.Coinbase, baseFee)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -458,6 +458,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		fee := new(big.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTip)
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
+
+		// collect base fee instead of burn
+		if st.evm.Context.Coinbase.Cmp(common.Address{}) != 0 {
+			baseFee := new(big.Int).SetUint64(st.gasUsed())
+			baseFee.Mul(baseFee, st.evm.Context.BaseFee)
+			st.state.AddBalance(st.evm.Context.Coinbase, baseFee)
+		}
 	}
 
 	return &ExecutionResult{


### PR DESCRIPTION
EIP-1559 burns the base fee. This doesn't make sense for rollups. The set fee recipient should collect it.