### PR TITLE
feat: remove txs which do not end up in a block out of the mempool

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -334,9 +334,11 @@ func New(config Config, chain BlockChain) *BlobPool {
 	}
 }
 
-func (p *BlobPool) SetAstriaOrdered(types.Transactions) {}
-func (p *BlobPool) ClearAstriaOrdered()                 {}
-func (p *BlobPool) AstriaOrdered() *types.Transactions  { return &types.Transactions{} }
+func (p *BlobPool) SetAstriaOrdered(types.Transactions)    {}
+func (p *BlobPool) ClearAstriaOrdered()                    {}
+func (p *BlobPool) UpdateAstriaInvalid(*types.Transaction) {}
+func (p *BlobPool) AstriaInvalid() *types.Transactions     { return &types.Transactions{} }
+func (p *BlobPool) AstriaOrdered() *types.Transactions     { return &types.Transactions{} }
 
 // Filter returns whether the given transaction can be consumed by the blob pool.
 func (p *BlobPool) Filter(tx *types.Transaction) bool {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -334,11 +334,11 @@ func New(config Config, chain BlockChain) *BlobPool {
 	}
 }
 
-func (p *BlobPool) SetAstriaOrdered(types.Transactions)    {}
-func (p *BlobPool) ClearAstriaOrdered()                    {}
-func (p *BlobPool) UpdateAstriaInvalid(*types.Transaction) {}
-func (p *BlobPool) AstriaInvalid() *types.Transactions     { return &types.Transactions{} }
-func (p *BlobPool) AstriaOrdered() *types.Transactions     { return &types.Transactions{} }
+func (p *BlobPool) SetAstriaOrdered(types.Transactions)              {}
+func (p *BlobPool) ClearAstriaOrdered()                              {}
+func (p *BlobPool) UpdateAstriaExcludedFromBlock(*types.Transaction) {}
+func (p *BlobPool) AstriaExcludedFromBlock() *types.Transactions     { return &types.Transactions{} }
+func (p *BlobPool) AstriaOrdered() *types.Transactions               { return &types.Transactions{} }
 
 // Filter returns whether the given transaction can be consumed by the blob pool.
 func (p *BlobPool) Filter(tx *types.Transaction) bool {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -334,11 +334,11 @@ func New(config Config, chain BlockChain) *BlobPool {
 	}
 }
 
-func (p *BlobPool) SetAstriaOrdered(types.Transactions)              {}
-func (p *BlobPool) ClearAstriaOrdered()                              {}
-func (p *BlobPool) UpdateAstriaExcludedFromBlock(*types.Transaction) {}
-func (p *BlobPool) AstriaExcludedFromBlock() *types.Transactions     { return &types.Transactions{} }
-func (p *BlobPool) AstriaOrdered() *types.Transactions               { return &types.Transactions{} }
+func (p *BlobPool) SetAstriaOrdered(types.Transactions)             {}
+func (p *BlobPool) ClearAstriaOrdered()                             {}
+func (p *BlobPool) AddToAstriaExcludedFromBlock(*types.Transaction) {}
+func (p *BlobPool) AstriaExcludedFromBlock() *types.Transactions    { return &types.Transactions{} }
+func (p *BlobPool) AstriaOrdered() *types.Transactions              { return &types.Transactions{} }
 
 // Filter returns whether the given transaction can be consumed by the blob pool.
 func (p *BlobPool) Filter(tx *types.Transaction) bool {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -320,6 +320,7 @@ func (pool *LegacyPool) SetAstriaOrdered(txs types.Transactions) {
 func (pool *LegacyPool) UpdateAstriaInvalid(tx *types.Transaction) {
 	if pool.astria.invalid == nil {
 		pool.astria.invalid = types.Transactions{tx}
+		return
 	}
 
 	pool.astria.invalid = append(pool.astria.invalid, tx)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -317,7 +317,7 @@ func (pool *LegacyPool) SetAstriaOrdered(txs types.Transactions) {
 	pool.astria = newAstriaOrdered(valid, pool)
 }
 
-func (pool *LegacyPool) UpdateAstriaExcludedFromBlock(tx *types.Transaction) {
+func (pool *LegacyPool) AddToAstriaExcludedFromBlock(tx *types.Transaction) {
 	if pool.astria.excludedFromBlock == nil {
 		pool.astria.excludedFromBlock = types.Transactions{tx}
 		return
@@ -340,7 +340,12 @@ func (pool *LegacyPool) ClearAstriaOrdered() {
 
 	astriaExcludedFromBlockMeter.Mark(int64(len(pool.astria.excludedFromBlock)))
 	for _, tx := range pool.astria.excludedFromBlock {
-		pool.removeTx(tx.Hash(), false, true)
+		n := pool.removeTx(tx.Hash(), false, true)
+		if n == 0 {
+			log.Trace("astria tx excluded from block not found in mempool", "hash", tx.Hash())
+		} else {
+			log.Trace("astria tx excluded from block removed from mempool", "hash", tx.Hash())
+		}
 	}
 
 	pool.astria.clear()

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -140,7 +140,7 @@ type SubPool interface {
 
 	SetAstriaOrdered(types.Transactions)
 	ClearAstriaOrdered()
-	UpdateAstriaExcludedFromBlock(tx *types.Transaction)
+	AddToAstriaExcludedFromBlock(tx *types.Transaction)
 	AstriaExcludedFromBlock() *types.Transactions
 	AstriaOrdered() *types.Transactions
 }

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -140,7 +140,7 @@ type SubPool interface {
 
 	SetAstriaOrdered(types.Transactions)
 	ClearAstriaOrdered()
-	UpdateAstriaInvalid(tx *types.Transaction)
-	AstriaInvalid() *types.Transactions
+	UpdateAstriaExcludedFromBlock(tx *types.Transaction)
+	AstriaExcludedFromBlock() *types.Transactions
 	AstriaOrdered() *types.Transactions
 }

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -140,5 +140,7 @@ type SubPool interface {
 
 	SetAstriaOrdered(types.Transactions)
 	ClearAstriaOrdered()
+	UpdateAstriaInvalid(tx *types.Transaction)
+	AstriaInvalid() *types.Transactions
 	AstriaOrdered() *types.Transactions
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -273,17 +273,17 @@ func (p *TxPool) ClearAstriaOrdered() {
 	}
 }
 
-func (p *TxPool) UpdateAstriaInvalid(tx *types.Transaction) {
+func (p *TxPool) UpdateAstriaExcludedFromBlock(tx *types.Transaction) {
 	for _, subpool := range p.subpools {
-		subpool.UpdateAstriaInvalid(tx)
+		subpool.UpdateAstriaExcludedFromBlock(tx)
 	}
 }
 
-func (p *TxPool) AstriaInvalid() *types.Transactions {
+func (p *TxPool) AstriaExcludedFromBlock() *types.Transactions {
 	txs := types.Transactions{}
 
 	for _, subpool := range p.subpools {
-		subpoolTxs := subpool.AstriaInvalid()
+		subpoolTxs := subpool.AstriaExcludedFromBlock()
 		txs = append(txs, *subpoolTxs...)
 	}
 

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -273,9 +273,9 @@ func (p *TxPool) ClearAstriaOrdered() {
 	}
 }
 
-func (p *TxPool) UpdateAstriaExcludedFromBlock(tx *types.Transaction) {
+func (p *TxPool) AddToAstriaExcludedFromBlock(tx *types.Transaction) {
 	for _, subpool := range p.subpools {
-		subpool.UpdateAstriaExcludedFromBlock(tx)
+		subpool.AddToAstriaExcludedFromBlock(tx)
 	}
 }
 

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -273,6 +273,23 @@ func (p *TxPool) ClearAstriaOrdered() {
 	}
 }
 
+func (p *TxPool) UpdateAstriaInvalid(tx *types.Transaction) {
+	for _, subpool := range p.subpools {
+		subpool.UpdateAstriaInvalid(tx)
+	}
+}
+
+func (p *TxPool) AstriaInvalid() *types.Transactions {
+	txs := types.Transactions{}
+
+	for _, subpool := range p.subpools {
+		subpoolTxs := subpool.AstriaInvalid()
+		txs = append(txs, *subpoolTxs...)
+	}
+
+	return &txs
+}
+
 func (p *TxPool) AstriaOrdered() *types.Transactions {
 	txs := types.Transactions{}
 

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -176,10 +176,7 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 
 // buildPayload builds the payload according to the provided parameters.
 func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
-	// Build the initial version with no transaction included. It should be fast
-	// enough to run. The empty payload can at least make sure there is something
-	// to deliver for not missing slot.
-	emptyParams := &generateParams{
+	fullParams := &generateParams{
 		timestamp:   args.Timestamp,
 		forceTime:   true,
 		parentHash:  args.Parent,
@@ -190,7 +187,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		noTxs:       false,
 	}
 	start := time.Now()
-	full := w.getSealingBlock(emptyParams)
+	full := w.getSealingBlock(fullParams)
 	if full.err != nil {
 		return nil, full.err
 	}

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -184,7 +184,7 @@ func TestBuildPayload(t *testing.T) {
 
 			// Ensure invalid transactions are stored
 			if len(tt.invalidTxs) > 0 {
-				invalidTxs := b.TxPool().AstriaInvalid()
+				invalidTxs := b.TxPool().AstriaExcludedFromBlock()
 				txDifference := types.TxDifference(*invalidTxs, signedInvalidTxs)
 				if txDifference.Len() != 0 {
 					t.Fatalf("Unexpected invalid transactions in astria invalid transactions: %v", txDifference)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -811,7 +811,7 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		if env.gasPool.Gas() < params.TxGas {
 			log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", params.TxGas)
 			// remove txs from the mempool if they are too big for this block
-			w.eth.TxPool().UpdateAstriaExcludedFromBlock(tx)
+			w.eth.TxPool().AddToAstriaExcludedFromBlock(tx)
 			break
 		}
 
@@ -823,7 +823,7 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		// phase, start ignoring the sender until we do.
 		if tx.Protected() && !w.chainConfig.IsEIP155(env.header.Number) {
 			log.Trace("Ignoring reply protected transaction", "hash", tx.Hash(), "eip155", w.chainConfig.EIP155Block)
-			w.eth.TxPool().UpdateAstriaExcludedFromBlock(tx)
+			w.eth.TxPool().AddToAstriaExcludedFromBlock(tx)
 			continue
 		}
 		// Start executing the transaction
@@ -859,7 +859,7 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		}
 		if err != nil {
 			log.Trace("Marking transaction as invalid", "hash", tx.Hash(), "err", err)
-			w.eth.TxPool().UpdateAstriaExcludedFromBlock(tx)
+			w.eth.TxPool().AddToAstriaExcludedFromBlock(tx)
 		}
 	}
 	if !w.isRunning() && len(coalescedLogs) > 0 {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -811,7 +811,7 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		if env.gasPool.Gas() < params.TxGas {
 			log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", params.TxGas)
 			// remove txs from the mempool if they are too big for this block
-			w.eth.TxPool().UpdateAstriaInvalid(tx)
+			w.eth.TxPool().UpdateAstriaExcludedFromBlock(tx)
 			break
 		}
 
@@ -823,7 +823,7 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		// phase, start ignoring the sender until we do.
 		if tx.Protected() && !w.chainConfig.IsEIP155(env.header.Number) {
 			log.Trace("Ignoring reply protected transaction", "hash", tx.Hash(), "eip155", w.chainConfig.EIP155Block)
-			w.eth.TxPool().UpdateAstriaInvalid(tx)
+			w.eth.TxPool().UpdateAstriaExcludedFromBlock(tx)
 			continue
 		}
 		// Start executing the transaction
@@ -859,7 +859,7 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		}
 		if err != nil {
 			log.Trace("Marking transaction as invalid", "hash", tx.Hash(), "err", err)
-			w.eth.TxPool().UpdateAstriaInvalid(tx)
+			w.eth.TxPool().UpdateAstriaExcludedFromBlock(tx)
 		}
 	}
 	if !w.isRunning() && len(coalescedLogs) > 0 {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -160,7 +160,6 @@ func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
-	backend.txPool.Add(pendingTxs, true, false)
 	w := newWorker(testConfig, chainConfig, engine, backend, new(event.TypeMux), nil, false)
 	w.setEtherbase(testBankAddress)
 	return w, backend


### PR DESCRIPTION
When the txs we receive from `ExecuteBlocks` call fail to end up in a block, we keep them lying around the geth mempool but clear it from the astria mempool.
This PR attempts to remove such txs from the geth mempool.