### PR TITLE
fix: continue the tx validation loop if assetId length check fails 

### DIFF
--- a/grpc/execution/server.go
+++ b/grpc/execution/server.go
@@ -250,6 +250,7 @@ func (s *ExecutionServiceServerV1Alpha2) ExecuteBlock(ctx context.Context, req *
 
 			if len(deposit.AssetId) != 32 {
 				log.Debug("ignoring deposit tx with invalid asset ID", "assetID", deposit.AssetId)
+				continue
 			}
 			assetID := [32]byte{}
 			copy(assetID[:], deposit.AssetId[:32])


### PR DESCRIPTION
Currently, we check if the length of the assetId sent by the rollup is of 32 bytes. If the check fails, we still continue executing the code which will lead to a panic as in the subsequent we try to index the bytes. 

The fix would be to ignore this tx when the validation fails