### PR TITLE
ci: update the test ci to run build/ci.go

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           go-version: 1.21.4
       - name: Run tests
-        run: go test -short ./...
+        run: go run build/ci.go test
         env:
           GOOS: linux


### PR DESCRIPTION
Previously, the test ci was running `go test -short ./...`. Instead run the build/ci.go to better test on the ci