### PR TITLE
fix: forkdiff page

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -12,11 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1000  # make sure to fetch the old commit we diff against
-          
-      - name: fetch geth release
-        run: |
-          git fetch origin go-ethereum/release/1.14.3
+          fetch-depth: 0  # Fetch all history for all tags and branches
 
       - name: Build forkdiff
         uses: "docker://protolambda/forkdiff:latest"


### PR DESCRIPTION
Currently forkdiff page build fails with `failed to find git ref`. Now fetches all the history instead.

