### PR TITLE
refactor: allow sender to be configurable per bridge.

### DIFF
--- a/genesis.json
+++ b/genesis.json
@@ -30,6 +30,7 @@
             },
             {
                 "bridgeAddress": "astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z",
+                "senderAddress": "0x0000000000000000000000000000000000000000",
                 "startHeight": 1,
                 "assetDenom": "transfer/channel-1/usdc",
                 "assetPrecision": 6,
@@ -39,7 +40,6 @@
                 }
             }
         ],
-        "astriaBridgeSenderAddress": "0x0000000000000000000000000000000000000000",
         "astriaFeeCollectors": {
             "1": "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
         },

--- a/grpc/execution/server.go
+++ b/grpc/execution/server.go
@@ -48,7 +48,6 @@ type ExecutionServiceServerV1Alpha2 struct {
 
 	bridgeAddresses     map[string]*params.AstriaBridgeAddressConfig // astria bridge addess to config for that bridge account
 	bridgeAllowedAssets map[string]struct{}                          // a set of allowed asset IDs structs are left empty
-	bridgeSenderAddress common.Address                               // address from which AstriaBridgeableERC20 contracts are called
 
 	nextFeeRecipient common.Address // Fee recipient for the next block
 }
@@ -113,7 +112,7 @@ func NewExecutionServiceServerV1Alpha2(eth *eth.Ethereum) (*ExecutionServiceServ
 				nativeBridgeSeen = true
 			}
 
-			if cfg.Erc20Asset != nil && bc.Config().AstriaBridgeSenderAddress == (common.Address{}) {
+			if cfg.Erc20Asset != nil && cfg.SenderAddress == (common.Address{}) {
 				return nil, errors.New("astria bridge sender address must be set for bridged ERC20 assets")
 			}
 
@@ -149,7 +148,6 @@ func NewExecutionServiceServerV1Alpha2(eth *eth.Ethereum) (*ExecutionServiceServ
 		bc:                  bc,
 		bridgeAddresses:     bridgeAddresses,
 		bridgeAllowedAssets: bridgeAllowedAssets,
-		bridgeSenderAddress: bc.Config().AstriaBridgeSenderAddress,
 		nextFeeRecipient:    nextFeeRecipient,
 	}, nil
 }
@@ -264,7 +262,7 @@ func (s *ExecutionServiceServerV1Alpha2) ExecuteBlock(ctx context.Context, req *
 
 	txsToProcess := types.Transactions{}
 	for _, tx := range req.Transactions {
-		unmarshalledTx, err := validateAndUnmarshalSequencerTx(height, tx, s.bridgeAddresses, s.bridgeAllowedAssets, s.bridgeSenderAddress)
+		unmarshalledTx, err := validateAndUnmarshalSequencerTx(height, tx, s.bridgeAddresses, s.bridgeAllowedAssets)
 		if err != nil {
 			log.Debug("failed to validate sequencer tx, ignoring", "tx", tx, "err", err)
 			continue

--- a/grpc/execution/test_utils.go
+++ b/grpc/execution/test_utils.go
@@ -67,6 +67,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block, stri
 	config.AstriaBridgeAddressConfigs = []params.AstriaBridgeAddressConfig{
 		{
 			BridgeAddress:  bech32mBridgeAddress,
+			SenderAddress:  common.Address{},
 			StartHeight:    2,
 			AssetDenom:     "nria",
 			AssetPrecision: 18,

--- a/grpc/execution/validation.go
+++ b/grpc/execution/validation.go
@@ -1,16 +1,17 @@
 package execution
 
 import (
-	astriaPb "buf.build/gen/go/astria/execution-apis/protocolbuffers/go/astria/execution/v1alpha2"
-	sequencerblockv1alpha1 "buf.build/gen/go/astria/sequencerblock-apis/protocolbuffers/go/astria/sequencerblock/v1alpha1"
 	"crypto/sha256"
 	"fmt"
+	"math/big"
+
+	astriaPb "buf.build/gen/go/astria/execution-apis/protocolbuffers/go/astria/execution/v1alpha2"
+	sequencerblockv1alpha1 "buf.build/gen/go/astria/sequencerblock-apis/protocolbuffers/go/astria/sequencerblock/v1alpha1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/contracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"math/big"
 )
 
 // `validateAndUnmarshalSequencerTx` validates and unmarshals the given rollup sequencer transaction.
@@ -22,7 +23,6 @@ func validateAndUnmarshalSequencerTx(
 	tx *sequencerblockv1alpha1.RollupData,
 	bridgeAddresses map[string]*params.AstriaBridgeAddressConfig,
 	bridgeAllowedAssets map[string]struct{},
-	bridgeSenderAddress common.Address,
 ) (*types.Transaction, error) {
 	if deposit := tx.GetDeposit(); deposit != nil {
 		bridgeAddress := deposit.BridgeAddress.GetBech32M()
@@ -62,7 +62,7 @@ func validateAndUnmarshalSequencerTx(
 			}
 
 			txdata := types.DepositTx{
-				From:  bridgeSenderAddress,
+				From:  bac.SenderAddress,
 				Value: new(big.Int), // don't need to set this, as we aren't minting the native asset
 				// mints cost ~14k gas, however this can vary based on existing storage, so we add a little extra as buffer.
 				//
@@ -78,7 +78,7 @@ func validateAndUnmarshalSequencerTx(
 		}
 
 		txdata := types.DepositTx{
-			From:  bridgeSenderAddress,
+			From:  bac.SenderAddress,
 			To:    &recipient,
 			Value: amount,
 			Gas:   0,

--- a/grpc/execution/validation_test.go
+++ b/grpc/execution/validation_test.go
@@ -180,7 +180,7 @@ func TestSequenceTxValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			_, err := validateAndUnmarshalSequencerTx(2, test.sequencerTx, serviceV1Alpha1.bridgeAddresses, serviceV1Alpha1.bridgeAllowedAssets, common.Address{})
+			_, err := validateAndUnmarshalSequencerTx(2, test.sequencerTx, serviceV1Alpha1.bridgeAddresses, serviceV1Alpha1.bridgeAllowedAssets)
 			if test.wantErr == "" && err == nil {
 				return
 			}

--- a/params/config.go
+++ b/params/config.go
@@ -386,7 +386,6 @@ type ChainConfig struct {
 	AstriaCelestiaInitialHeight    uint64                      `json:"astriaCelestiaInitialHeight"`
 	AstriaCelestiaHeightVariance   uint64                      `json:"astriaCelestiaHeightVariance,omitempty"`
 	AstriaBridgeAddressConfigs     []AstriaBridgeAddressConfig `json:"astriaBridgeAddresses,omitempty"`
-	AstriaBridgeSenderAddress      common.Address              `json:"astriaBridgeSenderAddress,omitempty"`
 	AstriaFeeCollectors            map[uint32]common.Address   `json:"astriaFeeCollectors"`
 	AstriaEIP1559Params            *AstriaEIP1559Params        `json:"astriaEIP1559Params,omitempty"`
 }
@@ -1055,6 +1054,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 
 type AstriaBridgeAddressConfig struct {
 	BridgeAddress  string                  `json:"bridgeAddress"`
+	SenderAddress  common.Address          `json:"senderAddress,omitempty"`
 	StartHeight    uint32                  `json:"startHeight"`
 	AssetDenom     string                  `json:"assetDenom"`
 	AssetPrecision uint16                  `json:"assetPrecision"`


### PR DESCRIPTION
allow sender to be configurable per bridge.

closes #46