### PR TITLE
fix: use mutex lock for tx removal

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -338,6 +338,8 @@ func (pool *LegacyPool) ClearAstriaOrdered() {
 	if pool.astria == nil {
 		return
 	}
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 
 	astriaExcludedFromBlockMeter.Mark(int64(len(pool.astria.excludedFromBlock)))
 	for _, tx := range pool.astria.excludedFromBlock {


### PR DESCRIPTION
Acquire a mutex lock and unlock to avoid concurrent errors on the underlying maps