### PR TITLE
try IBC prefixed asset when matching deposit

### DIFF
--- a/grpc/execution/validation.go
+++ b/grpc/execution/validation.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -39,8 +40,9 @@ func validateAndUnmarshalSequencerTx(
 			return nil, fmt.Errorf("disallowed asset %s in deposit tx", deposit.Asset)
 		}
 
-		if deposit.Asset != bac.AssetDenom {
-			return nil, fmt.Errorf("asset %s does not match bridge address %s asset", deposit.Asset, bridgeAddress)
+		assetHash := sha256.Sum256([]byte(deposit.Asset))
+		if deposit.Asset != bac.AssetDenom && ("ibc/" + hex.EncodeToString(assetHash[:])) != bac.AssetDenom {
+			return nil, fmt.Errorf("neither trace nor IBC prefixed asset %s match bridge address %s asset", deposit.Asset, bridgeAddress)
 		}
 
 		recipient := common.HexToAddress(deposit.DestinationChainAddress)


### PR DESCRIPTION
Previously, if a deposit came in which had an IBC prefixed asset (which is allowed by sequencer), matching the asset against that which is used by the bridge account would fail, since geth is using trace-prefixed. It now checks for the IBC-prefixed asset as well.