### PR TITLE
fix various static check errors

### DIFF
--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
-	primitivev1 "buf.build/gen/go/astria/primitives/protocolbuffers/go/astria/primitive/v1"
 )
 
 var _ TxData = &DepositTx{}
@@ -26,8 +25,8 @@ type DepositTx struct {
 	// to the `mint` function calldata.
 	Data []byte
 	// the transaction ID of the source action for the deposit, consisting
-  	// of the transaction hash.
-	SourceTransactionId primitivev1.TransactionId
+	// of the transaction hash.
+	SourceTransactionId string
 	// index of the deposit's source action within its transaction
 	SourceTransactionIndex uint64
 }
@@ -39,12 +38,12 @@ func (tx *DepositTx) copy() TxData {
 	}
 
 	cpy := &DepositTx{
-		From:  tx.From,
-		Value: new(big.Int),
-		Gas:   tx.Gas,
-		To:    to,
-		Data:  make([]byte, len(tx.Data)),
-		SourceTransactionId: tx.SourceTransactionId,
+		From:                   tx.From,
+		Value:                  new(big.Int),
+		Gas:                    tx.Gas,
+		To:                     to,
+		Data:                   make([]byte, len(tx.Data)),
+		SourceTransactionId:    tx.SourceTransactionId,
 		SourceTransactionIndex: tx.SourceTransactionIndex,
 	}
 

--- a/grpc/execution/server.go
+++ b/grpc/execution/server.go
@@ -194,7 +194,7 @@ func (s *ExecutionServiceServerV1) GetBlock(ctx context.Context, req *astriaPb.G
 // BatchGetBlocks will return an array of Blocks given an array of block
 // identifiers.
 func (s *ExecutionServiceServerV1) BatchGetBlocks(ctx context.Context, req *astriaPb.BatchGetBlocksRequest) (*astriaPb.BatchGetBlocksResponse, error) {
-	if req.Identifiers == nil || len(req.Identifiers) == 0 {
+	if len(req.Identifiers) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "identifiers cannot be empty")
 	}
 

--- a/grpc/execution/validation.go
+++ b/grpc/execution/validation.go
@@ -71,7 +71,7 @@ func validateAndUnmarshalSequencerTx(
 				Gas:                    64000,
 				To:                     &bac.Erc20Asset.ContractAddress,
 				Data:                   calldata,
-				SourceTransactionId:    *deposit.SourceTransactionId,
+				SourceTransactionId:    deposit.SourceTransactionId.GetInner(),
 				SourceTransactionIndex: deposit.SourceActionIndex,
 			}
 
@@ -84,7 +84,7 @@ func validateAndUnmarshalSequencerTx(
 			To:                     &recipient,
 			Value:                  amount,
 			Gas:                    0,
-			SourceTransactionId:    *deposit.SourceTransactionId,
+			SourceTransactionId:    deposit.SourceTransactionId.GetInner(),
 			SourceTransactionIndex: deposit.SourceActionIndex,
 		}
 		return types.NewTx(&txdata), nil
@@ -115,7 +115,7 @@ func validateStaticExecuteBlockRequest(req *astriaPb.ExecuteBlockRequest) error 
 		return fmt.Errorf("PrevBlockHash cannot be nil")
 	}
 	if req.Timestamp == nil {
-		return fmt.Errorf("Timestamp cannot be nil")
+		return fmt.Errorf("timestamp cannot be nil")
 	}
 
 	return nil


### PR DESCRIPTION
fix various static check errors, amongst which changes `DepositTx.SourceTransactionId` to string because using the proto type results in the following lock copy:
```
literal copies lock value from *deposit.SourceTransactionId: buf.build/gen/go/astria/primitives/protocolbuffers/go/astria/primitive/v1.TransactionId contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
```