### PR TITLE
fix: consider nil error while commiting a transaction

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -285,6 +285,8 @@ func (miner *Miner) commitAstriaTransactions(env *environment, txs *types.Transa
 		case errors.Is(err, core.ErrNonceTooLow):
 			// New head notification data race between the transaction pool and miner, shift
 			log.Trace("Skipping transaction with low nonce", "sender", from, "nonce", tx.Nonce())
+		case errors.Is(err, nil):
+			// Transaction successfully applied, continue
 		default:
 			// Strange error, discard the transaction and get the next in line (note, the
 			// nonce-too-high clause will prevent us from executing in vain).


### PR DESCRIPTION
After commiting a transaction during the block building process, we check if there was any error and log accordingly. We were not considering the case where error is `nil` due to which we end up hitting the default case in the switch stmt which leads to an incorrect log being logged. 
This PR considers the `nil` error case where we just don't log anything