### PR TITLE
Fix typo state_object.go

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -240,7 +240,7 @@ func (s *stateObject) SetState(key, value common.Hash) {
 }
 
 // setState updates a value in account dirty storage. If the value being set is
-// nil (assuming journal revert), the dirtyness is removed.
+// nil (assuming journal revert), the dirtiness is removed.
 func (s *stateObject) setState(key common.Hash, value *common.Hash) {
 	// If the first set is being reverted, undo the dirty marker
 	if value == nil {


### PR DESCRIPTION
# Fix typo in `state_object.go`

## Description
This PR fixes a typo in the `state_object.go` file where "dirtyness" was incorrectly spelled. It has been corrected to "dirtiness."

## Changes
- **File:** `core/state/state_object.go`
- **Line:** 240
- **Change:** Replaced "dirtyness" with "dirtiness."
