### PR TITLE
feat!: change injected tx type key

### DIFF
--- a/core/types/injected_tx.go
+++ b/core/types/injected_tx.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"math/big"
 
-	primitivev1 "buf.build/gen/go/astria/primitives/protocolbuffers/go/astria/primitive/v1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -30,7 +29,7 @@ type InjectedTx struct {
 	Data []byte
 	// the transaction ID of the source action on the sequencer, consisting
 	// of the transaction hash.
-	SourceTransactionId primitivev1.TransactionId
+	SourceTransactionId string
 	// index of the source action within its sequencer transaction
 	SourceTransactionIndex uint64
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -49,7 +49,7 @@ const (
 	AccessListTxType = 0x01
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
-	InjectedTxType   = 0x04
+	InjectedTxType   = 0x5a
 )
 
 // Transaction is an Ethereum transaction.

--- a/grpc/execution/validation.go
+++ b/grpc/execution/validation.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 
 	astriaPb "buf.build/gen/go/astria/execution-apis/protocolbuffers/go/astria/execution/v2"
-	primitivev1 "buf.build/gen/go/astria/primitives/protocolbuffers/go/astria/primitive/v1"
 	sequencerblockv1 "buf.build/gen/go/astria/sequencerblock-apis/protocolbuffers/go/astria/sequencerblock/v1"
 	connecttypesv2 "buf.build/gen/go/astria/vendored/protocolbuffers/go/connect/types/v2"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -135,7 +134,7 @@ func validateAndConvertPriceFeedDataTx(
 			Gas:                    100000,
 			To:                     &cfg.oracleContractAddress,
 			Data:                   calldata,
-			SourceTransactionId:    primitivev1.TransactionId{},
+			SourceTransactionId:    "",
 			SourceTransactionIndex: 0,
 		}
 		tx := types.NewTx(&txdata)
@@ -158,8 +157,8 @@ func validateAndConvertPriceFeedDataTx(
 		Gas:                    900000,
 		To:                     &cfg.oracleContractAddress,
 		Data:                   calldata,
-		SourceTransactionId:    primitivev1.TransactionId{}, // not relevant
-		SourceTransactionIndex: 0,                           // not relevant
+		SourceTransactionId:    "", // not relevant
+		SourceTransactionIndex: 0,  // not relevant
 	}
 	log.Debug("created setPrices tx", "pairs", priceFeedData.Prices)
 	tx := types.NewTx(&txdata)
@@ -214,7 +213,7 @@ func validateAndConvertDepositTx(
 			Gas:                    64000,
 			To:                     &bac.Erc20Asset.ContractAddress,
 			Data:                   calldata,
-			SourceTransactionId:    *deposit.SourceTransactionId,
+			SourceTransactionId:    deposit.SourceTransactionId.Inner,
 			SourceTransactionIndex: deposit.SourceActionIndex,
 		}
 
@@ -226,7 +225,7 @@ func validateAndConvertDepositTx(
 		To:                     &recipient,
 		Value:                  amount,
 		Gas:                    0,
-		SourceTransactionId:    *deposit.SourceTransactionId,
+		SourceTransactionId:    deposit.SourceTransactionId.Inner,
 		SourceTransactionIndex: deposit.SourceActionIndex,
 	}
 	return []*types.Transaction{types.NewTx(&txdata)}, nil


### PR DESCRIPTION
This is a block hash breaking change to Astria Geth for any chain which has utilized deposits. It has been validated to NOT be state breaking against various running instances. 

Changes the transaction code used for injected txs to be 0x5a from 0x04 to avoid collisions with new eth transactions, and specialty codes used in arbitrum & optimism.

Since already breaking transactions, simplified to use strings instead of protos for better determinism.