### PR TITLE
fix: updates for determinism and error checking

### DIFF
--- a/precompile/config/config.go
+++ b/precompile/config/config.go
@@ -29,7 +29,7 @@ func GetPrecompiles(chainConfig *params.ChainConfig, height uint64, timestamp ui
 	// Initialize precompiles for this fork
 	precompiles := make(precompile.PrecompileMap)
 	for addr, precompileType := range fork.Precompiles {
-		switch precompileType {
+		switch *precompileType {
 		case params.PrecompileBase64:
 			precompiles[addr] = pcbase64.NewBase64()
 		default:


### PR DESCRIPTION
- adds some additional error cases in update commitment state
- updates fork extra data to be deterministic, and cached
- makes `CreateExecutionSession` consume other execution locks
- minor warnings and error checks called out by ide (alias matching name, unused error)