### PR TITLE
allow geth node to specify a trusted celestia height

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -211,6 +211,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 			eth,
 			ctx.Bool(utils.ExecutionServiceSoftAsFirmFlag.Name),
 			ctx.Uint64(utils.ExecutionServiceSoftAsFirmMaxHeightFlag.Name),
+			ctx.Uint64(utils.ExecutionServiceTrustedCelestiaHeightFlag.Name),
 		)
 		if err != nil {
 			utils.Fatalf("failed to create execution service: %v", err)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -158,6 +158,7 @@ var (
 		utils.BeaconCheckpointFlag,
 		utils.ExecutionServiceSoftAsFirmFlag,
 		utils.ExecutionServiceSoftAsFirmMaxHeightFlag,
+		utils.ExecutionServiceTrustedCelestiaHeightFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -896,6 +896,11 @@ var (
 		Usage:    "Max height for soft commitment to be used as firm commitment",
 		Category: flags.ExecutionCategory,
 	}
+	ExecutionServiceTrustedCelestiaHeightFlag = &cli.Uint64Flag{
+		Name:     "execution.trusted-celestia-height",
+		Usage:    "Height of the minimum Celestia block that is trusted (use to bump celestia search height after running in soft-as-firm mode)",
+		Category: flags.ExecutionCategory,
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = &cli.BoolFlag{

--- a/grpc/execution/test_utils.go
+++ b/grpc/execution/test_utils.go
@@ -169,7 +169,7 @@ func setupExecutionService(t *testing.T, noOfBlocksToGenerate int, lowGasLimit b
 	genesis, blocks, bridgeAddress, feeCollectorKey := generateMergeChain(noOfBlocksToGenerate, true, gasLimit, isHalted)
 	ethservice := startEthService(t, genesis)
 
-	serviceV2, err := NewExecutionServiceServerV2(ethservice, false, 0)
+	serviceV2, err := NewExecutionServiceServerV2(ethservice, false, 0, 0)
 	require.Nil(t, err, "can't create execution service")
 
 	fork := genesis.Config.AstriaForks.GetForkAtHeight(1)


### PR DESCRIPTION
Allows geth node to specify a trusted celestia height that can be used for the `LowestCelestiaSearchHeight` when creating execution sessions.

Previous logic was `max ( recorded base celestia height, fork celestia start height )`

New logic is `max ( trusted celestia height, recorded base celestia height, fork celestia start height )`

Meant to be used after running in `soft-as-firm` mode, to allow conductor to skip searching old celestia blocks for the next firm height
