### PR TITLE
feat: Oracle source tx id

### DIFF
--- a/grpc/execution/server.go
+++ b/grpc/execution/server.go
@@ -274,7 +274,7 @@ func (s *ExecutionServiceServerV2) ExecuteBlock(ctx context.Context, req *astria
 	}
 
 	for _, tx := range req.Transactions {
-		txs, err := validateAndConvertSequencerTx(ctx, height, tx, conversionConfig)
+		txs, err := validateAndConvertSequencerTx(ctx, height, tx, conversionConfig, req.SequencerBlockHash)
 		if err != nil {
 			log.Info("failed to validate sequencer tx, ignoring", "tx", tx, "err", err)
 			continue

--- a/grpc/execution/validation.go
+++ b/grpc/execution/validation.go
@@ -1,8 +1,10 @@
 package execution
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -29,6 +31,26 @@ func hashCurrencyPair(currencyPair *connecttypesv2.CurrencyPair) [32]byte {
 	return bytes
 }
 
+// Create a unique source transaction ID for price feed data transactions
+func createPriceFeedSourceTxId(height uint64, header *types.Header, priceFeedData *sequencerblockv1.PriceFeedData) string {
+	var buffer bytes.Buffer
+
+	binary.Write(&buffer, binary.BigEndian, height)
+
+	binary.Write(&buffer, binary.BigEndian, header.Time)
+
+	for _, price := range priceFeedData.Prices {
+		buffer.WriteString(price.CurrencyPair.Base)
+		buffer.WriteString(price.CurrencyPair.Quote)
+		binary.Write(&buffer, binary.BigEndian, price.Price.Hi)
+		binary.Write(&buffer, binary.BigEndian, price.Price.Lo)
+	}
+
+	hash := crypto.Keccak256(buffer.Bytes())
+
+	return hex.EncodeToString(hash)
+}
+
 func validateAndConvertPriceFeedDataTx(
 	ctx context.Context,
 	height uint64,
@@ -49,6 +71,9 @@ func validateAndConvertPriceFeedDataTx(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get state and header for height %d: %w", height-1, err)
 	}
+
+	// create a unique source transaction ID for the price feed data update
+	sourceTxId := createPriceFeedSourceTxId(height, header, priceFeedData)
 
 	// arguments for calling the `setPrices()` function on the oracle contract
 	currencyPairsToSet := make([][32]byte, 0)
@@ -134,7 +159,7 @@ func validateAndConvertPriceFeedDataTx(
 			Gas:                    100000,
 			To:                     &cfg.oracleContractAddress,
 			Data:                   calldata,
-			SourceTransactionId:    "",
+			SourceTransactionId:    sourceTxId,
 			SourceTransactionIndex: 0,
 		}
 		tx := types.NewTx(&txdata)
@@ -157,8 +182,8 @@ func validateAndConvertPriceFeedDataTx(
 		Gas:                    900000,
 		To:                     &cfg.oracleContractAddress,
 		Data:                   calldata,
-		SourceTransactionId:    "", // not relevant
-		SourceTransactionIndex: 0,  // not relevant
+		SourceTransactionId:    sourceTxId,
+		SourceTransactionIndex: 0,
 	}
 	log.Debug("created setPrices tx", "pairs", priceFeedData.Prices)
 	tx := types.NewTx(&txdata)

--- a/grpc/execution/validation_test.go
+++ b/grpc/execution/validation_test.go
@@ -187,7 +187,7 @@ func TestSequenceTxValidation(t *testing.T) {
 				bridgeAddresses:     fork.BridgeAddresses,
 				bridgeAllowedAssets: fork.BridgeAllowedAssets,
 			}
-			_, err := validateAndConvertSequencerTx(context.Background(), 2, test.sequencerTx, cfg)
+			_, err := validateAndConvertSequencerTx(context.Background(), 2, test.sequencerTx, cfg, "")
 			if test.wantErr == "" && err == nil {
 				return
 			}


### PR DESCRIPTION
Generate a source transaction id for oracle price feed data to prevent duplicate transactions if price is the same.