### PR TITLE
fix: Add check for callstack len == 0

### DIFF
--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -220,6 +220,10 @@ func (t *callTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	if err != nil {
 		return
 	}
+	if len(t.callstack) == 0 {
+		// No calls were traced
+		return
+	}
 	t.callstack[0].GasUsed = receipt.GasUsed
 	if t.config.WithLog {
 		// Logs are not emitted when the call fails

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -244,6 +244,10 @@ func (t *callTracer) OnLog(log *types.Log) {
 	if t.interrupt.Load() {
 		return
 	}
+	// No calls were traced
+	if len(t.callstack) == 0 {
+		return
+	}
 	l := callLog{
 		Address:  log.Address,
 		Topics:   log.Topics,


### PR DESCRIPTION
`OnTxEnd` and `OnLog` can crash if the `callTracer.callstack` has a length of 0.
This pr adds a check and return if that is the case.